### PR TITLE
Creat chromosomes with random values

### DIFF
--- a/src/genetic.c
+++ b/src/genetic.c
@@ -20,8 +20,7 @@ Ptr_Chromosome create_chromosome(int id, const int chrom_length)
 
     Ptr_Chromosome chrom = NULL;
 
-    // Random seed initialization from current system time.
-    srand(time(NULL));
+
 
     // Memory allocation
     chrom = (Ptr_Chromosome)malloc(sizeof(struct Chromosome));

--- a/src/genetic.c
+++ b/src/genetic.c
@@ -295,6 +295,7 @@ int genetic_main(Ptr_config config)
     for ( i = 0 ; i < TOTAL_CHROM ; i++ )
     {
         List_Chromosome[i] = create_chromosome(i, CHROMOSOME_LENGTH);
+        seed_with_random_values(List_Chromosome[i],CHROMOSOME_LENGTH);
     }
 
     rep_best = 0;


### PR DESCRIPTION
1. Delete srand() in create_chromosome()
Chromosomes are created in a for-loop and srand(time(null)) is meaningless within a second. It's possible to cause make seed_with_random_values() to malfuction.  

2. In genetic_main, call seed_with_random_values() when chromosomes are created.
When created the chromosomes ,they are not filled with random values.
 